### PR TITLE
Change NXPower Builds to use Centos 7.7 instead of Centos 7.3

### DIFF
--- a/kernel/kernel.yaml
+++ b/kernel/kernel.yaml
@@ -7,8 +7,3 @@ Package:
  version:
   file: 'Makefile'
   regex: 'VERSION.*([\d.]+)\nPATCHLEVEL\s*=\s*(?P<patch>[\d.]*)\nSUBLEVEL\s*=\s*(?(patch)([\d.]*))\nEXTRAVERSION\s*=\s*([-\w.]*)\n'
- files:
-  CentOS:
-   '7':
-    build_dependencies:
-     - 'gcc'

--- a/open-power-host-os/CentOS/7/open-power-host-os.spec
+++ b/open-power-host-os/CentOS/7/open-power-host-os.spec
@@ -49,32 +49,11 @@ Summary: OpenPOWER Host OS full package set
 Requires: %{name}-base = %{version}-%{release}
 Requires(post): kernel = 4.9.85-1%{dist}%{?buildid}
 Requires: %{name}-container = %{version}-%{release}
-Requires(post): docker = 2:1.12.2-47%{dist}
-Requires(post): docker-swarm = 1.1.0-1.gita0fd82b
-Requires(post): flannel = 0.5.5-1.gitcb8284f%{dist}
-Requires(post): kubernetes = 1.2.0-0.21.git4a3f9c5%{dist}
 Requires: %{name}-virt = %{version}-%{release}
-Requires(post): SLOF = 20170303-2%{dist}%{?buildid}
 Requires(post): libvirt = 2.0.0-11%{dist}.5%{?buildid}
 Requires(post): qemu-kvm = 10:2.6.0-28%{dist}.9%{?buildid}
 Requires: %{name}-ras = %{version}-%{release}
-Requires(post): crash = 7.1.6-1.git64531dc%{dist}
-Requires(post): hwdata = 0.288-1.git625a119%{dist}
-Requires(post): libnl3 = 3.2.28-4%{dist}
-Requires(post): librtas = 1.4.1-2.git3fe4911%{dist}
-Requires(post): libservicelog = 1.1.16-2.git48875ee%{dist}
-Requires(post): libvpd = 2.2.5-4.git8cb3fe0%{dist}
-Requires(post): lshw = B.02.18-1.gitf9bdcc3
-Requires(post): lsvpd = 1.7.7-6.git3a5f5e1%{dist}
-Requires(post): ppc64-diag = 2.7.2-1.gitd56f7f1%{dist}
 Requires(post): servicelog = 1.1.14-4.git7d33cd3%{dist}
-Requires(post): sos = 3.3-18.git52dd1db%{dist}
-Requires(post): systemtap = 3.1-2%{dist}
-
-Requires(post): gcc = 4.8.5-12.svn240558%{dist}
-Requires(post): golang-github-russross-blackfriday = 1:1.2-6.git5f33e7b%{dist}
-Requires(post): golang-github-shurcooL-sanitized_anchor_name = 1:0-1.git1dba4b3%{dist}
-Requires(post): golang = 1.7.1-3%{dist}
 
 %description all
 %{summary}
@@ -99,11 +78,6 @@ Summary: OpenPOWER Host OS container packages
 Requires: %{name}-base = %{version}-%{release}
 Requires(post): kernel = 4.10.0-7.gitb729957%{dist}
 
-Requires(post): docker = 2:1.12.2-47%{dist}
-Requires(post): docker-swarm = 1.1.0-1.gita0fd82b
-Requires(post): flannel = 0.5.5-1.gitcb8284f%{dist}
-Requires(post): kubernetes = 1.2.0-0.21.git4a3f9c5%{dist}
-
 %description container
 %{summary}
 
@@ -114,8 +88,6 @@ Summary: OpenPOWER Host OS hypervisor packages
 
 Requires: %{name}-base = %{version}-%{release}
 Requires(post): kernel = 4.9.85-1%{dist}%{?buildid}
-
-Requires(post): SLOF = 20170303-2%{dist}%{?buildid}
 Requires(post): libvirt = 2.0.0-11%{dist}.5%{?buildid}
 Requires(post): qemu-kvm = 10:2.6.0-28%{dist}.9%{?buildid}
 
@@ -128,19 +100,8 @@ Summary: OpenPOWER Host OS RAS (Reliability Availability Serviceability) package
 
 Requires: %{name}-base = %{version}-%{release}
 Requires(post): kernel = 4.9.85-1%{dist}%{?buildid}
-
-Requires(post): crash = 7.1.6-1.git64531dc%{dist}
 Requires(post): hwdata = 0.288-1.git625a119%{dist}
-Requires(post): libnl3 = 3.2.28-4%{dist}
-Requires(post): librtas = 1.4.1-2.git3fe4911%{dist}
-Requires(post): libservicelog = 1.1.16-2.git48875ee%{dist}
-Requires(post): libvpd = 2.2.5-4.git8cb3fe0%{dist}
-Requires(post): lshw = B.02.18-1.gitf9bdcc3
-Requires(post): lsvpd = 1.7.7-6.git3a5f5e1%{dist}
-Requires(post): ppc64-diag = 2.7.2-1.gitd56f7f1%{dist}
 Requires(post): servicelog = 1.1.14-4.git7d33cd3%{dist}
-Requires(post): sos = 3.3-18.git52dd1db%{dist}
-Requires(post): systemtap = 3.1-2%{dist}
 
 %description ras
 %{summary}

--- a/open-power-host-os/open-power-host-os.yaml
+++ b/open-power-host-os/open-power-host-os.yaml
@@ -3,26 +3,8 @@ Package:
   CentOS:
    '7':
     install_dependencies:
-     - SLOF
-     - crash
-     - docker-swarm
-     - docker
-     - flannel
-     - gcc
-     - golang-github-russross-blackfriday
-     - golang-github-shurcooL-sanitized_anchor_name
-     - golang
      - hwdata
      - kernel
-     - libnl3
-     - librtas
-     - libservicelog
      - libvirt
-     - libvpd
-     - lshw
-     - lsvpd
-     - ppc64-diag
      - qemu
      - servicelog
-     - sos
-     - systemtap

--- a/ppc64-diag/ppc64-diag.yaml
+++ b/ppc64-diag/ppc64-diag.yaml
@@ -4,8 +4,3 @@ Package:
      src: 'https://github.com/open-power-host-os/ppc64-diag.git'
      branch: 'hostos-devel'
      commit_id: 'd56f7f1367bd6634605fd65997170252696178fa'
- files:
-  CentOS:
-   '7':
-    build_dependencies:
-     - 'librtas'

--- a/qemu/CentOS/7/qemu.spec
+++ b/qemu/CentOS/7/qemu.spec
@@ -1,5 +1,5 @@
-%global SLOF_gittagdate 20160223
-%global SLOF_gittagcommit dbbfda4
+%global SLOF_gittagdate 20171214
+%global SLOF_gittagcommit a98132
 
 %global have_usbredir 1
 %global have_spice    0
@@ -89,7 +89,7 @@ Requires: seavgabios-bin >= 1.9.1-4
 Requires: ipxe-roms-qemu >= 20160127-4
 %endif
 %ifarch %{power64}
-Requires: SLOF >= %{SLOF_gittagdate}-1.git%{SLOF_gittagcommit}
+Requires: SLOF >= %{SLOF_gittagdate}-3.git%{SLOF_gittagcommit}
 %endif
 Requires: %{pkgname}-common%{?pkgsuffix} = %{epoch}:%{version}-%{release}
 %if %{have_seccomp}

--- a/servicelog/servicelog.yaml
+++ b/servicelog/servicelog.yaml
@@ -7,8 +7,3 @@ Package:
  version:
   file: 'configure.ac'
   regex: 'm4_define\(\[ppu_version\],\s*([\d.]+)\)'
- files:
-  CentOS:
-   '7':
-    build_dependencies:
-     - 'libservicelog'


### PR DESCRIPTION
Centos 7.3.1611 no longer builds with EPEL 7 as there are unresolved
package dependencies.  EPEL 7 has a dependency on the package
python-srpm-macros which was introduced in Centos 7.7.  There are a
couple of other missing dependencies as well.  EPEL does not provide
point in time snapshots of its code, so the only resolution is to
upgrade the distro to Centos 7.7.

This drives a second set of changes in that some of the packages
provided by NXPower are now downlevel to the distro.  None of these
packages were modified by Nutanix, so they are simply being removed
from the build list.  The distro provided packages will be used instead.
Downlevel packages to the distro that are being removed:

- gcc                   Old version: 4.8.5-12     Distro: 4.8.5-39
- librtas               Old version: 1.4.1        Distro: 2.0.1-2
- libservicelog         Old version: 1.1.16-2     Distro: 1.1.18-1
- crash                 Old version: 7.1.6.1      Distro: 7.2.3.10
- SLOF                  Old version: 20170303-2   Distro: 20171214-3
- libvpd                Old version: 2.2.5-4      Distro: 2.2.6
- lsvpd                 Old version: 1.7.7-6      Distro: 1.7.9-1

There are also directories in NXPower/versions for projects such as
docker, docker-swarm, flannel, and golang.  These directories are not
built by NXPower/builds.  They are simply inherited from the cloned
project open-power-host-os/versions.  They could be removed.

The list of projects to be built are identified in the file
NXPower/versions/open-power-host-os/open-power-host-os.yaml.  After
removing the obsolete packages above, only five projects remain:
hwdata, kernel, libvirt, qemu, and servicelog.  openvswitch is also
built as it is specified in the %build section of the spec file
open-power-host-os.spec.  Finally, the package nutanix-ahv and its
dependent package tunctl are built as they are explicitly listed as
package requirements in NXPower/builds/config.yaml.

Signed-off-by: Luke Browning [IBM] <918375@nutanix.com>